### PR TITLE
FIX: dark/light theme issues with status bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.maderskitech.androidcodingexerciseapp"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/MainActivity.kt
@@ -71,7 +71,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun UpdateStatusBarForTheme(activity: Activity, isDarkTheme: Boolean) {
     val view = LocalView.current
-    val window = (view.context as Activity).window
+    val window = activity.window
     val lifecycleOwner = LocalLifecycleOwner.current
     val useLightIcons = !isDarkTheme
 

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/MainActivity.kt
@@ -1,11 +1,13 @@
 package com.maderskitech.androidcodingexerciseapp.presentation
 
+import android.app.Activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,13 +22,19 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.maderskitech.androidcodingexerciseapp.presentation.model.ItemGroup
 import com.maderskitech.androidcodingexerciseapp.presentation.ui.theme.AndroidCodingExerciseAppTheme
 import com.maderskitech.kmpcodingexercisenetwork.domain.model.Item
@@ -40,8 +48,11 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             AndroidCodingExerciseAppTheme {
+                var isDark = isSystemInDarkTheme()
+                var backgroundColor = if (isDark) Color.Black else Color.White
+                UpdateStatusBarForTheme(this@MainActivity, isDark)
                 Scaffold(modifier = Modifier
-                    .background(Color.Black)
+                    .background(backgroundColor)
                     .safeDrawingPadding()
                 ) { innerPadding ->
                     DisplayItemsScreen(
@@ -54,6 +65,32 @@ class MainActivity : ComponentActivity() {
         }
 
         viewModel.fetchItems()
+    }
+}
+
+@Composable
+private fun UpdateStatusBarForTheme(activity: Activity, isDarkTheme: Boolean) {
+    val view = LocalView.current
+    val window = (view.context as Activity).window
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val useLightIcons = !isDarkTheme
+
+    DisposableEffect(lifecycleOwner, isDarkTheme) {
+        val insetsController = WindowInsetsControllerCompat(window, view)
+
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                insetsController.isAppearanceLightStatusBars = useLightIcons
+            }
+        }
+
+        insetsController.isAppearanceLightStatusBars = useLightIcons
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 }
 


### PR DESCRIPTION
## Description
When switching from the Dark them to the light theme the status bar icons where being hidden due to them being black on a black background.

## Receipt
| Before | After |
|-----|---------|
| ![Before](https://github.com/user-attachments/assets/8e2fc999-767c-46f4-a7fb-ed98b6bb4e45) | ![After](https://github.com/user-attachments/assets/15f0d438-53c1-462e-865c-5b1d0083241c) |
