### PR TITLE
refactor: move the viewmodel to be provided to the screen instead of the activity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     // Koin
     implementation(libs.koin.android)
     implementation(libs.koin.compose)
+    implementation(libs.koin.compose.viewmodel)
 
     // KTOR Engine for Android
     implementation(libs.ktor.client.okhttp)

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/application/di/AppModule.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/application/di/AppModule.kt
@@ -1,9 +1,9 @@
 package com.maderskitech.androidcodingexerciseapp.application.di
 
-import com.maderskitech.androidcodingexerciseapp.presentation.MainViewModel
+import com.maderskitech.androidcodingexerciseapp.presentation.displayitems.DisplayItemsViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val appModule = module {
-    viewModelOf(::MainViewModel)
+    viewModelOf(::DisplayItemsViewModel)
 }

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/MainActivity.kt
@@ -5,43 +5,19 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import com.maderskitech.androidcodingexerciseapp.presentation.model.ItemGroup
+import com.maderskitech.androidcodingexerciseapp.presentation.displayitems.DisplayItemsScreen
 import com.maderskitech.androidcodingexerciseapp.presentation.ui.theme.AndroidCodingExerciseAppTheme
-import com.maderskitech.kmpcodingexercisenetwork.domain.model.Item
-import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : ComponentActivity() {
-    private val viewModel: MainViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,20 +27,9 @@ class MainActivity : ComponentActivity() {
                 var isDark = isSystemInDarkTheme()
                 var backgroundColor = if (isDark) Color.Black else Color.White
                 UpdateStatusBarForTheme(this@MainActivity, isDark)
-                Scaffold(modifier = Modifier
-                    .background(backgroundColor)
-                    .safeDrawingPadding()
-                ) { innerPadding ->
-                    DisplayItemsScreen(
-                        isLoading = viewModel.isLoading,
-                        itemGroups = viewModel.itemGroups,
-                        innerPadding = innerPadding
-                    )
-                }
+                DisplayItemsScreen(backgroundColor)
             }
         }
-
-        viewModel.fetchItems()
     }
 }
 
@@ -92,96 +57,4 @@ private fun UpdateStatusBarForTheme(activity: Activity, isDarkTheme: Boolean) {
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
-}
-
-@Composable
-private fun DisplayItemsScreen(
-    isLoading: Boolean,
-    itemGroups: List<ItemGroup>,
-    innerPadding: PaddingValues
-) {
-    if (isLoading) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            CircularProgressIndicator()
-        }
-    } else {
-        GroupedLazyColumn(itemGroups, innerPadding)
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun GroupedLazyColumn(
-    itemGroups: List<ItemGroup>,
-    innerPadding: PaddingValues,
-    modifier: Modifier = Modifier
-) {
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        contentPadding = innerPadding
-    ) {
-        itemGroups.forEach { itemGroup ->
-            stickyHeader {
-                GroupHeader("List ID: ${itemGroup.listId}")
-            }
-            items(
-                items = itemGroup.items,
-                key = { it.id }
-            ) { item ->
-                ListItem(
-                    headlineContent = {
-                        Text(item.name)
-                    },
-                    supportingContent = {
-                        Text("ID: ${item.id}")
-                    },
-                    trailingContent = {
-                        Text("List ID: ${item.listId}")
-                    }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun GroupHeader(
-    text: String,
-    modifier: Modifier = Modifier
-) {
-    Text(
-        text = text,
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Bold,
-        modifier = modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.primaryContainer)
-            .padding(16.dp)
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun PreviewDisplayItemsScreen() {
-    DisplayItemsScreen(
-        false,
-        listOf(
-            ItemGroup(1, listOf(Item(100, 1, "Item 100"), Item(101, 1, "Item 101"), Item(102, 1, "Item 202"))),
-            ItemGroup(2, listOf(Item(200, 2, "Item 200"), Item(201, 2, "Item 201"), Item(202, 2, "Item 202")))
-        ),
-        PaddingValues(8.dp)
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun PreviewDisplayItemsScreenLoading() {
-    DisplayItemsScreen(
-        true,
-        emptyList(),
-        PaddingValues(8.dp)
-    )
 }

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/DisplayItemsScreen.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/DisplayItemsScreen.kt
@@ -1,0 +1,27 @@
+package com.maderskitech.androidcodingexerciseapp.presentation.displayitems
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.maderskitech.androidcodingexerciseapp.presentation.displayitems.composables.DisplayItemsScreenContent
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun DisplayItemsScreen(
+    backgroundColor: Color,
+    viewModel: DisplayItemsViewModel = koinViewModel()
+) {
+    Scaffold(modifier = Modifier
+        .background(backgroundColor)
+        .safeDrawingPadding()
+    ) { innerPadding ->
+        DisplayItemsScreenContent(
+            isLoading = viewModel.isLoading,
+            itemGroups = viewModel.itemGroups,
+            innerPadding = innerPadding
+        )
+    }
+}

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/DisplayItemsViewModel.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/DisplayItemsViewModel.kt
@@ -1,4 +1,4 @@
-package com.maderskitech.androidcodingexerciseapp.presentation
+package com.maderskitech.androidcodingexerciseapp.presentation.displayitems
 
 import android.util.Log
 import androidx.compose.runtime.getValue
@@ -6,16 +6,20 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.maderskitech.androidcodingexerciseapp.presentation.model.ItemGroup
+import com.maderskitech.androidcodingexerciseapp.presentation.displayitems.model.ItemGroup
 import com.maderskitech.kmpcodingexercisenetwork.domain.respository.ItemRepository
 import kotlinx.coroutines.launch
 
-class MainViewModel(private val itemsRepository: ItemRepository) : ViewModel() {
+class DisplayItemsViewModel(private val itemsRepository: ItemRepository) : ViewModel() {
     var isLoading by mutableStateOf(false)
         private set
 
     var itemGroups by mutableStateOf<List<ItemGroup>>(emptyList())
         private set
+
+    init {
+        fetchItems()
+    }
 
     fun fetchItems() {
         isLoading = true

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/composables/DisplayItemsScreenContent.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/composables/DisplayItemsScreenContent.kt
@@ -1,0 +1,54 @@
+package com.maderskitech.androidcodingexerciseapp.presentation.displayitems.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.maderskitech.androidcodingexerciseapp.presentation.displayitems.model.ItemGroup
+import com.maderskitech.kmpcodingexercisenetwork.domain.model.Item
+
+@Composable
+fun DisplayItemsScreenContent(
+    isLoading: Boolean,
+    itemGroups: List<ItemGroup>,
+    innerPadding: PaddingValues
+) {
+    if (isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    } else {
+        GroupedLazyColumn(itemGroups, innerPadding)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewDisplayItemsScreenContent() {
+    DisplayItemsScreenContent(
+        false,
+        listOf(
+            ItemGroup(1, listOf(Item(100, 1, "Item 100"), Item(101, 1, "Item 101"), Item(102, 1, "Item 202"))),
+            ItemGroup(2, listOf(Item(200, 2, "Item 200"), Item(201, 2, "Item 201"), Item(202, 2, "Item 202")))
+        ),
+        PaddingValues(8.dp)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewDisplayItemsScreenContentLoading() {
+    DisplayItemsScreenContent(
+        true,
+        emptyList(),
+        PaddingValues(8.dp)
+    )
+}

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/composables/GroupedHeader.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/composables/GroupedHeader.kt
@@ -1,0 +1,28 @@
+package com.maderskitech.androidcodingexerciseapp.presentation.displayitems.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun GroupHeader(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.primaryContainer)
+            .padding(16.dp)
+    )
+}

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/composables/GroupedLazyColumn.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/composables/GroupedLazyColumn.kt
@@ -1,0 +1,48 @@
+package com.maderskitech.androidcodingexerciseapp.presentation.displayitems.composables
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.maderskitech.androidcodingexerciseapp.presentation.displayitems.model.ItemGroup
+import kotlin.collections.forEach
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun GroupedLazyColumn(
+    itemGroups: List<ItemGroup>,
+    innerPadding: PaddingValues,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = innerPadding
+    ) {
+        itemGroups.forEach { itemGroup ->
+            stickyHeader {
+                GroupHeader("List ID: ${itemGroup.listId}")
+            }
+            items(
+                items = itemGroup.items,
+                key = { it.id }
+            ) { item ->
+                ListItem(
+                    headlineContent = {
+                        Text(item.name)
+                    },
+                    supportingContent = {
+                        Text("ID: ${item.id}")
+                    },
+                    trailingContent = {
+                        Text("List ID: ${item.listId}")
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/model/ItemGroup.kt
+++ b/app/src/main/java/com/maderskitech/androidcodingexerciseapp/presentation/displayitems/model/ItemGroup.kt
@@ -1,4 +1,4 @@
-package com.maderskitech.androidcodingexerciseapp.presentation.model
+package com.maderskitech.androidcodingexerciseapp.presentation.displayitems.model
 
 import com.maderskitech.kmpcodingexercisenetwork.domain.model.Item
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 # Koin DI
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
 
 # Ktor
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }


### PR DESCRIPTION
# Description
Improve package structure and move the viewmodel to be provided by the screen instead of the activity.

# Receipt
![refactorproof](https://github.com/user-attachments/assets/b7430a85-56f4-4b0e-936b-530ae2ce925d)
